### PR TITLE
Add endpoint for download

### DIFF
--- a/cq_server/exporter.py
+++ b/cq_server/exporter.py
@@ -165,3 +165,15 @@ class Exporter:
             self.save_to(op.join(js_path, f'{ module_name }.js'), 'js')
             self.save_to(op.join(png_path, f'{ module_name }.png'), 'png')
             self.save_to(op.join(stl_path, f'{ module_name }.stl'), 'stl')
+
+    def export(self, module: str, file_format: str) -> str:
+        mm = self.module_manager.get_module()
+        self.module_manager.set_module(mm[0], module)
+        name = module.split(".")[0]
+        tmpdir = tempfile.mkdtemp()
+        file = name+"."+file_format
+        destination = op.join(tmpdir, file)
+        self._save(destination, file_format)
+        self.module_manager.set_module(mm[0], mm[1])
+        return destination
+

--- a/cq_server/module_manager.py
+++ b/cq_server/module_manager.py
@@ -41,6 +41,13 @@ class ModuleManager:
         sys.path.insert(1, self.modules_dir)
         self.available_modules = self.get_available_modules()
 
+    def get_module(self) -> (str,str):
+        return (self.modules_dir, self.module_name)
+
+    def set_module(self, modules_dir: str, module_name: str):
+        self.modules_dir = modules_dir
+        self.module_name = module_name
+
     def get_available_modules(self) -> Dict[str, str]:
         '''Returns a dictionary of available modules as module name: module path'''
 


### PR DESCRIPTION
You can now download your models using the endpoint /download. You need to specify the parameters `m` for which module and `format` for which format you want it in.

Ex: `localhost:5000/download?m=box.py&format=stl`  
Will produce `box.stl` for download.

Things of note:
 - Unsure about the 404-error thrown willy-nilly.
 - Don't know if the getting and setting of `module_manager` values are really necessary.
 - Style. Python is not my strong side. My code looks very different from yours.