### PR TITLE
 Keep Camera Settings Between Model View Refreshes

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-	"recommendations": [
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"samuelcolvin.jinjahtml"
-	]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "files.associations": {
-        "*.html": "jinja-html"
-    },
-    "python.linting.pylintEnabled": true,
-    "editor.rulers": [
-        100
-    ]
-}

--- a/cq_server/static/viewer.js
+++ b/cq_server/static/viewer.js
@@ -132,10 +132,14 @@ function show_model() {
 
 function render(_data) {
 	data = _data;
+	let cameraSettings
 
 	if ( ! viewer) {
 		init_viewer(options, modules_name);
 	} else {
+		try {
+			cameraSettings = viewer.getCameraLocationSettings();
+		} catch(error) { console.log(error) }
 		viewer.clear();
 	}
 
@@ -145,6 +149,9 @@ function render(_data) {
 		show_error();
 	} else if (data.module_name) {
 		show_model();
+		try {
+			viewer.setCameraLocationSettings(cameraSettings.position, cameraSettings.quaternion, cameraSettings.target, cameraSettings.zoom);
+		} catch(error) { console.log(error) }
 	} else {
 		show_index();
 	}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Flask = "^2.2.2"
 jupyter-cadquery = "^3.2.2"
 cadquery-massembly = "^0.9.0"
 matplotlib = "^3.5.3"
-minify-html = "^0.10.0"
+minify-html = "^0.9.0"
 cadquery = {version = "2.2.0b0", optional = true, allow-prereleases = true}
 casadi = {version = "^3.5.6rc2", optional = true, allow-prereleases = true}
 CairoSVG = "^2.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Flask = "^2.2.2"
 jupyter-cadquery = "^3.2.2"
 cadquery-massembly = "^0.9.0"
 matplotlib = "^3.5.3"
-minify-html = "^0.9.0"
+minify-html = "^0.10.0"
 cadquery = {version = "2.2.0b0", optional = true, allow-prereleases = true}
 casadi = {version = "^3.5.6rc2", optional = true, allow-prereleases = true}
 CairoSVG = "^2.5.2"


### PR DESCRIPTION
Camera settings are saved before viewer is cleared and loaded after model is shown, resulting in persistent camera settings across (automatic) refreshes. Tested before in the vscode extension and seems to work well here too.

(sorry about the spam, git hard, me dumb)