### PR TITLE
Add toast when model reloading in progress

### DIFF
--- a/cq_server/module_manager.py
+++ b/cq_server/module_manager.py
@@ -6,6 +6,7 @@ import sys
 from typing import List, Dict, Tuple
 import glob
 import json
+from time import time
 
 
 IGNORE_FILE_NAME = '.cqsignore'
@@ -185,9 +186,13 @@ class ModuleManager:
 
         if self.module_name:
             try:
+                start_time = time()
+                model = self.get_json_model()
+                end_time = time()
                 data = {
                     'module_name': self.module_name,
-                    'model': self.get_json_model(),
+                    'model': model,
+                    'time_elapsed': end_time - start_time,
                     'source': ''
                 }
             except ModuleManagerError as error:

--- a/cq_server/server.py
+++ b/cq_server/server.py
@@ -13,7 +13,8 @@ from .module_manager import ModuleManager
 
 
 WATCH_PERIOD = 0.3
-SSE_MESSAGE_TEMPLATE = 'event: file_update\ndata: %s\n\n'
+SSE_FILE_UPDATE_MESSAGE_TEMPLATE = 'event: file_update\ndata: %s\n\n'
+SSE_LOADING_MODEL_MESSAGE_TEMPLATE = 'event: loading_model\ndata: %s\n\n'
 
 
 app = Flask(__name__, static_url_path='/static')
@@ -74,8 +75,9 @@ def run(port: int, module_manager: ModuleManager, ui_options: dict, is_dead: boo
 
             if last_updated_file:
                 module_manager.module_name = op.basename(last_updated_file)[:-3]
+                events_queue.put(SSE_LOADING_MODEL_MESSAGE_TEMPLATE % module_manager.module_name)
                 data = module_manager.get_data()
-                events_queue.put(SSE_MESSAGE_TEMPLATE % json.dumps(data))
+                events_queue.put(SSE_FILE_UPDATE_MESSAGE_TEMPLATE % json.dumps(data))
             sleep(WATCH_PERIOD)
 
     events_queue = Queue(maxsize = 3)

--- a/cq_server/static/viewer.css
+++ b/cq_server/static/viewer.css
@@ -34,6 +34,24 @@ body {
 	background-color: grey;
 }
 
+.toast {
+	position: absolute;
+	z-index: 1000;
+	left: 50%;
+	top: 56px;
+	transform: translate(-50%, -50%);
+	padding: 5px 20px;
+	border: 1px solid black;
+	border-radius: 5px;
+	background-color: #444;
+	opacity: 0.8;
+	font-family: sans-serif;
+	color: white;
+	font-weight: 100;
+	font-size: 14px;
+	text-align: center;
+}
+
 .cqs_module_item {
     margin: 0.5em;
 	display: inline-block;

--- a/cq_server/static/viewer.js
+++ b/cq_server/static/viewer.js
@@ -9,12 +9,20 @@ let modules_name = [];
 let viewer = null;
 let timer = null;
 let sse = null;
+let toast_timeout = null;
 
 
 function init_sse() {
 	sse = new EventSource('events');
+	sse.addEventListener('loading_model', event => {
+		const message = "Reloading model: " + event.data;
+		show_toast(message);
+	})
 	sse.addEventListener('file_update', event => {
-		render(JSON.parse(event.data));
+		const data = JSON.parse(event.data);
+		render(data);
+		hide_toast();
+		console.log(`${data.module_name}: model reloaded in ${data.time_elapsed.toFixed(2)} seconds`);
 	})
 	sse.onerror = error => {
 		if (sse.readyState == 2) {
@@ -52,6 +60,29 @@ function init_viewer(_options, _modules_name) {
 	if ('hideButtons' in options) {
 		viewer.trimUI(options.hideButtons, false);
 	}
+}
+
+function show_toast(message, duration = -1) {
+    if (toast_timeout) {
+        clearTimeout(toast_timeout);
+        toast_timeout = null;
+    }
+
+    document.getElementById('cqs_toast_message').innerText = message;
+    document.getElementById('cqs_toast').style.display = 'block';
+
+    if (duration !== -1) {
+        toast_timeout = setTimeout(hide_toast, duration);
+    }
+}
+
+function hide_toast() {
+    if (toast_timeout) {
+        clearTimeout(toast_timeout);
+        toast_timeout = null;
+    }
+
+    document.getElementById('cqs_toast').style.display = 'none';
 }
 
 function show_error() {

--- a/cq_server/templates/viewer.html
+++ b/cq_server/templates/viewer.html
@@ -25,6 +25,10 @@
 <body>
 	<div id="cad_view"></div>
 
+	<div class="toast" id="cqs_toast" style="display: none">
+		<span id="cqs_toast_message"></span>
+	</div>
+
 	<div class="modal error" id="cqs_error" style="display: none">
 		<h2>Oops! An error occured.</h2>
 		<p id="cqs_error_message"></p>


### PR DESCRIPTION
Hey @roipoussiere, thanks for this really cool project; I'm starting with CadQuery, and this definitely makes it more pleasant to use! 🙇 

To get a first glimpse at the code, thought I could start with something very small, and implement the feature request here: https://github.com/roipoussiere/cadquery-server/issues/75
As I also thought there's no clear feedback that something's running.

![cq-server_toast-when-reloading](https://github.com/roipoussiere/cadquery-server/assets/77339169/1bfe75b0-642c-4422-87b7-14aa06a148a3)

Cheers
