### PR TITLE
show_object(): fix alpha param

### DIFF
--- a/cq_server/module_manager.py
+++ b/cq_server/module_manager.py
@@ -146,7 +146,8 @@ class ModuleManager:
                 else MODEL_COLOR_DEFAULT
 
             if alpha:
-                color = Color(color.toTuple()[:3] + [ alpha ])
+                r, g, b = color.toTuple()[:3]
+                color = Color(r, g, b, alpha)
 
             try:
                 assembly.add(result.shape, color=color, name=name)


### PR DESCRIPTION
I'm unable to use the `alpha` parameter of `show_object`, because it tries to concatenate a tuple to a list.

![image](https://github.com/roipoussiere/cadquery-server/assets/77339169/6e17cb15-c08c-4405-a612-e0589167e705)
