### PR TITLE
Better exception handling: propagate and parse all exceptions

### DIFF
--- a/cq_server/module_manager.py
+++ b/cq_server/module_manager.py
@@ -6,6 +6,7 @@ import sys
 from typing import List, Dict, Tuple
 import glob
 import json
+import traceback
 
 
 IGNORE_FILE_NAME = '.cqsignore'
@@ -121,7 +122,7 @@ class ModuleManager:
         result = model.build()
 
         if not result.success:
-            raise ModuleManagerError('Error in model', result.exception)
+            raise ModuleManagerError('Error in model') from result.exception
 
         return result
 
@@ -196,7 +197,7 @@ class ModuleManager:
 
                 data = {
                     'error': error.message,
-                    'stacktrace': error.stacktrace
+                    'stacktrace': ''.join(traceback.format_exception(type(error), error, error.__traceback__))
                 }
 
         return data
@@ -215,12 +216,7 @@ class ModuleManager:
 class ModuleManagerError(Exception):
     '''Error class used to define ModuleManager errors.'''
 
-    def __init__(self, message: str, stacktrace: str=''):
+    def __init__(self, message: str):
         self.message = message
-        self.stacktrace = stacktrace
-
         print('Module manager error: ' + message, file=sys.stderr)
-        if stacktrace:
-            print(stacktrace, file=sys.stderr)
-
         super().__init__(self.message)

--- a/cq_server/static/viewer.css
+++ b/cq_server/static/viewer.css
@@ -15,11 +15,11 @@ body {
 	left: 10%;
 	top: 10%;
 	right: 10%;
-	bottom: 10%;
+	max-height: 80%;
 	padding: 1em;
 	font-family: sans-serif;
 	z-index: 1000;
-	overflow: scroll;
+	overflow: auto;
 }
 
 .modal.error {
@@ -31,7 +31,14 @@ body {
 }
 
 .modal pre {
-	background-color: grey;
+	display: inline-block;
+	padding: 10px;
+	background-color: #565656;
+	color: white;
+	box-sizing: border-box;
+	overflow: visible;
+	white-space: pre;
+	min-width: 100%;
 }
 
 .cqs_module_item {

--- a/cq_server/static/viewer.js
+++ b/cq_server/static/viewer.js
@@ -60,7 +60,6 @@ function show_error() {
 
 	document.getElementById('cqs_error_message').innerText = data.error;
 	document.getElementById('cqs_stacktrace').innerText = data.stacktrace;
-	document.getElementById('cqs_stacktrace').style.display = data.stacktrace ? 'block' : 'none';
 
 	document.getElementById('cqs_error').style.display = 'block';
 }


### PR DESCRIPTION
Propagate and parse all exceptions to be able to visualise them in the frontend.

Before:
![Screenshot 2023-07-12 at 22 27 50](https://github.com/roipoussiere/cadquery-server/assets/77339169/dce22aec-e44e-4a44-8c08-e8925e9d1710)

After:
![Screenshot 2023-07-12 at 22 28 18](https://github.com/roipoussiere/cadquery-server/assets/77339169/71ffdb06-2eaa-4594-b73f-7cb8e57cdabc)

🙇 